### PR TITLE
Remove Compose BOM

### DIFF
--- a/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose-jetbrains.gradle.kts
+++ b/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose-jetbrains.gradle.kts
@@ -39,7 +39,7 @@ gradleConventionsExtension.awaitComposeConfigured {
   // jetbrains compose plugin rewrites compose dependencies for android to point to androidx
   // if we want to use the compose BOM we need to rewrite the rewritten dependencies to not include a version
   // https://github.com/JetBrains/compose-multiplatform/issues/2502
-  if(androidComposeDependencyBomVersion != null) {
+  if(bomifyAndroidxComposeRewrites) {
     plugins.withType<BasePlugin> {
       android {
         dependencies {

--- a/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose.gradle.kts
+++ b/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose.gradle.kts
@@ -1,26 +1,13 @@
 import com.eygraber.conventions.gradleConventionsDefaultsService
 import com.eygraber.conventions.gradleConventionsExtension
-import com.android.build.gradle.BasePlugin as AndroidBasePlugin
 
 val ext = gradleConventionsExtension
 val composeDefaults = gradleConventionsDefaultsService.compose
 
 ext.compose.androidComposeCompilerVersionOverride = composeDefaults.androidComposeCompilerVersionOverride
-ext.compose.androidComposeDependencyBomVersion = composeDefaults.androidComposeDependencyBomVersion
 ext.compose.enableAndroidCompilerMetrics = composeDefaults.enableAndroidCompilerMetrics
 ext.compose.applyToAndroidAndJvmOnly = composeDefaults.applyToAndroidAndJvmOnly
 ext.compose.jetbrainsComposeCompilerOverride = composeDefaults.jetbrainsComposeCompilerOverride
 ext.compose.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion =
   composeDefaults.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion
-
-ext.awaitComposeConfigured {
-  plugins.withType<AndroidBasePlugin> {
-    android {
-      dependencies {
-        androidComposeDependencyBomVersion?.let { bomVersion ->
-          implementation(platform("androidx.compose:compose-bom:$bomVersion"))
-        }
-      }
-    }
-  }
-}
+ext.compose.bomifyAndroidxComposeRewrites = composeDefaults.bomifyAndroidxComposeRewrites

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
@@ -44,12 +44,12 @@ abstract class GradleConventionsPlugin : Plugin<Project> {
 
         awaitComposeConfigured {
           compose.androidComposeCompilerVersionOverride = androidComposeCompilerVersionOverride
-          compose.androidComposeDependencyBomVersion = androidComposeDependencyBomVersion
           compose.enableAndroidCompilerMetrics = enableAndroidCompilerMetrics
           compose.applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
           compose.jetbrainsComposeCompilerOverride = jetbrainsComposeCompilerOverride
           compose.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion =
             useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion
+          compose.bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
         }
 
         awaitDependenciesConfigured {

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/compose/GradleConventionsCompose.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/compose/GradleConventionsCompose.kt
@@ -9,11 +9,11 @@ import org.gradle.api.provider.Provider
 
 class GradleConventionsCompose {
   var androidComposeCompilerVersionOverride: String? = null
-  var androidComposeDependencyBomVersion: String? = null
   var enableAndroidCompilerMetrics: Boolean = false
   var applyToAndroidAndJvmOnly: Boolean = false
   var jetbrainsComposeCompilerOverride: MinimalExternalModuleDependency? = null
   var useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion: Boolean = false
+  var bomifyAndroidxComposeRewrites: Boolean = false
 
   @Suppress("ObjectPropertyNaming")
   companion object {
@@ -24,8 +24,6 @@ class GradleConventionsCompose {
   fun android(
     compilerVersionOverride: Provider<String>? = null,
     compilerOverride: Provider<MinimalExternalModuleDependency>? = null,
-    bomVersion: Provider<String>? = null,
-    bom: Provider<MinimalExternalModuleDependency>? = null,
     enableAndroidCompilerMetrics: Boolean = false
   ) {
     compilerVersionOverride?.let { androidComposeCompilerVersionOverride = it.get() }
@@ -40,35 +38,38 @@ class GradleConventionsCompose {
       }
       androidComposeCompilerVersionOverride = version
     }
-    bomVersion?.let { androidComposeDependencyBomVersion = it.get() }
-    bom?.let { androidComposeDependencyBomVersion = it.get().version }
     this.enableAndroidCompilerMetrics = enableAndroidCompilerMetrics
   }
 
   fun multiplatformWithAndroidCompiler(
     androidCompilerVersion: Provider<String>,
-    applyToAndroidAndJvmOnly: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false,
+    bomifyAndroidxComposeRewrites: Boolean = false
   ) {
     multiplatform(
       compilerMavenCoordinatesOverride = "$JetpackCompilerArtifact:$androidCompilerVersion",
-      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
+      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly,
+      bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
     )
   }
 
   fun multiplatformWithJetbrainsCompiler(
     jetbrainsCompilerVersion: Provider<String>,
-    applyToAndroidAndJvmOnly: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false,
+    bomifyAndroidxComposeRewrites: Boolean = false
   ) {
     multiplatform(
       compilerMavenCoordinatesOverride = "$JetbrainsCompilerArtifact:$jetbrainsCompilerVersion",
-      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
+      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly,
+      bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
     )
   }
 
   fun multiplatform(
     compilerMavenCoordinatesOverride: String? = null,
     compilerOverride: Provider<MinimalExternalModuleDependency>? = null,
-    applyToAndroidAndJvmOnly: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false,
+    bomifyAndroidxComposeRewrites: Boolean = false
   ) {
     if(compilerMavenCoordinatesOverride != null) {
       val coords = compilerMavenCoordinatesOverride.split(":")
@@ -94,5 +95,6 @@ class GradleConventionsCompose {
     }
     compilerOverride?.let { jetbrainsComposeCompilerOverride = it.get() }
     this.applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
+    this.bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
   }
 }


### PR DESCRIPTION
  - There's no need to hide this functionality
  - It also prevents a streamlined way of having Renovate find updates for the BOM