### PR TITLE
Remove Compose bomify completely

### DIFF
--- a/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose-jetbrains.gradle.kts
+++ b/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose-jetbrains.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.BasePlugin
 import com.eygraber.conventions.gradleConventionsExtension
 import org.jetbrains.compose.ComposeCompilerKotlinSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -34,41 +33,5 @@ gradleConventionsExtension.awaitComposeConfigured {
     compose.kotlinCompilerPlugin.set(
       "$group:$name${if(version == null) "" else ":$version"}"
     )
-  }
-
-  // jetbrains compose plugin rewrites compose dependencies for android to point to androidx
-  // if we want to use the compose BOM we need to rewrite the rewritten dependencies to not include a version
-  // https://github.com/JetBrains/compose-multiplatform/issues/2502
-  if(bomifyAndroidxComposeRewrites) {
-    plugins.withType<BasePlugin> {
-      android {
-        dependencies {
-          components {
-            all {
-              val isCompiler = id.group.endsWith("compiler")
-              val isCompose = id.group.startsWith("androidx.compose")
-              val isBom = id.name == "compose-bom"
-
-              val override = isCompose && !isCompiler && !isBom
-              if(override) {
-                listOf(
-                  "debugApiElements-published",
-                  "debugRuntimeElements-published",
-                  "releaseApiElements-published",
-                  "releaseRuntimeElements-published"
-                ).forEach { variantNameToAlter ->
-                  withVariant(variantNameToAlter) {
-                    withDependencies {
-                      removeAll { true } // remove androidx artifact with version
-                      add("${id.group}:${id.name}") // add androidx artifact without version
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
   }
 }

--- a/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose.gradle.kts
+++ b/conventions-plugin/src/main/kotlin/com.eygraber.conventions-compose.gradle.kts
@@ -10,4 +10,3 @@ ext.compose.applyToAndroidAndJvmOnly = composeDefaults.applyToAndroidAndJvmOnly
 ext.compose.jetbrainsComposeCompilerOverride = composeDefaults.jetbrainsComposeCompilerOverride
 ext.compose.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion =
   composeDefaults.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion
-ext.compose.bomifyAndroidxComposeRewrites = composeDefaults.bomifyAndroidxComposeRewrites

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
@@ -49,7 +49,6 @@ abstract class GradleConventionsPlugin : Plugin<Project> {
           compose.jetbrainsComposeCompilerOverride = jetbrainsComposeCompilerOverride
           compose.useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion =
             useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion
-          compose.bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
         }
 
         awaitProjectDependenciesConfigured {

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/compose/GradleConventionsCompose.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/compose/GradleConventionsCompose.kt
@@ -13,7 +13,6 @@ class GradleConventionsCompose {
   var applyToAndroidAndJvmOnly: Boolean = false
   var jetbrainsComposeCompilerOverride: MinimalExternalModuleDependency? = null
   var useAndroidComposeCompilerVersionForJetbrainsComposeCompilerVersion: Boolean = false
-  var bomifyAndroidxComposeRewrites: Boolean = false
 
   @Suppress("ObjectPropertyNaming")
   companion object {
@@ -43,33 +42,28 @@ class GradleConventionsCompose {
 
   fun multiplatformWithAndroidCompiler(
     androidCompilerVersion: Provider<String>,
-    applyToAndroidAndJvmOnly: Boolean = false,
-    bomifyAndroidxComposeRewrites: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false
   ) {
     multiplatform(
       compilerMavenCoordinatesOverride = "$JetpackCompilerArtifact:$androidCompilerVersion",
-      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly,
-      bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
+      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
     )
   }
 
   fun multiplatformWithJetbrainsCompiler(
     jetbrainsCompilerVersion: Provider<String>,
-    applyToAndroidAndJvmOnly: Boolean = false,
-    bomifyAndroidxComposeRewrites: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false
   ) {
     multiplatform(
       compilerMavenCoordinatesOverride = "$JetbrainsCompilerArtifact:$jetbrainsCompilerVersion",
-      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly,
-      bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
+      applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
     )
   }
 
   fun multiplatform(
     compilerMavenCoordinatesOverride: String? = null,
     compilerOverride: Provider<MinimalExternalModuleDependency>? = null,
-    applyToAndroidAndJvmOnly: Boolean = false,
-    bomifyAndroidxComposeRewrites: Boolean = false
+    applyToAndroidAndJvmOnly: Boolean = false
   ) {
     if(compilerMavenCoordinatesOverride != null) {
       val coords = compilerMavenCoordinatesOverride.split(":")
@@ -95,6 +89,5 @@ class GradleConventionsCompose {
     }
     compilerOverride?.let { jetbrainsComposeCompilerOverride = it.get() }
     this.applyToAndroidAndJvmOnly = applyToAndroidAndJvmOnly
-    this.bomifyAndroidxComposeRewrites = bomifyAndroidxComposeRewrites
   }
 }


### PR DESCRIPTION
  - Jetbrains did something and this works differently now
  - It may not even be needed as it looks like BOMs will override the Jetbrains versions in the consumer
  - Looking for clarification in https://github.com/JetBrains/compose-multiplatform/issues/2502