### PR TITLE
Fix detektAll task setup

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2g -Xms512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=1024m
 
 group=com.eygraber
-version=0.0.80-SNAPSHOT
+version=0.0.81-SNAPSHOT
 
 POM_URL=https://github.com/eygraber/gradle-conventions/
 POM_SCM_URL=https://github.com/eygraber/gradle-conventions/


### PR DESCRIPTION
  - Source sets that didn't have any ancestors (JVM, Android, WASI, etc...) weren't getting included