### PR TITLE
Disable isIncludeAndroidResources by default

### DIFF
--- a/conventions-plugin/src/main/kotlin/com.eygraber.conventions-android-library.gradle.kts
+++ b/conventions-plugin/src/main/kotlin/com.eygraber.conventions-android-library.gradle.kts
@@ -18,6 +18,7 @@ ext.android.compileSdk = androidDefaults.compileSdk
 ext.android.targetSdk = androidDefaults.targetSdk
 ext.android.minSdk = androidDefaults.minSdk
 ext.android.doNotRunLintWhenRunningReleaseBuildTasks = androidDefaults.doNotRunLintWhenRunningReleaseBuildTasks
+ext.android.isIncludeAndroidResources = androidDefaults.isIncludeAndroidResources
 ext.android.sourceCompatibility = androidDefaults.sourceCompatibility
 ext.android.targetCompatibility = androidDefaults.targetCompatibility
 ext.android.publishEverything = androidDefaults.publishEverything
@@ -126,7 +127,7 @@ ext.awaitAndroidConfigured { isAndroidUserConfigured ->
 
     testOptions {
       unitTests {
-        isIncludeAndroidResources = true
+        isIncludeAndroidResources = isIncludeAndroidResources
       }
     }
 

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/GradleConventionsPlugin.kt
@@ -43,6 +43,7 @@ abstract class GradleConventionsPlugin : Plugin<Project> {
           android.targetSdk = targetSdk
           android.minSdk = minSdk
           android.doNotRunLintWhenRunningReleaseBuildTasks = doNotRunLintWhenRunningReleaseBuildTasks
+          android.isIncludeAndroidResources = isIncludeAndroidResources
           android.sourceCompatibility = sourceCompatibility
           android.targetCompatibility = targetCompatibility
           android.publishEverything = publishEverything

--- a/conventions-plugin/src/main/kotlin/com/eygraber/conventions/android/GradleConventionsAndroid.kt
+++ b/conventions-plugin/src/main/kotlin/com/eygraber/conventions/android/GradleConventionsAndroid.kt
@@ -32,6 +32,11 @@ class GradleConventionsAndroid {
    */
   var doNotRunLintWhenRunningReleaseBuildTasks: Boolean? = null
 
+  /**
+   * If this is `true` then there will be test sources even if there are no tests, which will cause an error in Gradle 9
+   */
+  var isIncludeAndroidResources: Boolean = false
+
   internal var coreLibraryDesugaringDependency: Any? = null
 
   internal var flavors: MutableList<Pair<String, List<ProductFlavor>>> = mutableListOf()


### PR DESCRIPTION
  - The default was true until now
  - In Gradle 9 this causes an error if there are no test sources
  - If a test needs it, that module can set it to true